### PR TITLE
Use imageNamed rather than imageWithContentsOfFile so that different px densities are automatically resolved

### DIFF
--- a/CareKit/CareCard/OCKCareCardAdditionalInfoTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardAdditionalInfoTableViewCell.m
@@ -1,21 +1,21 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
- 
+
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
- 
+
  1.  Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
- 
+
  2.  Redistributions in binary form must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation and/or
  other materials provided with the distribution.
- 
+
  3.  Neither the name of the copyright holder(s) nor the names of any contributors
  may be used to endorse or promote products derived from this software without
  specific prior written permission. No license is granted to the trademarks of
  the copyright holders even if such marks are included in this software.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -61,21 +61,21 @@ static const CGFloat TrailingMargin = 20.0;
         _imageView.contentMode = UIViewContentModeScaleAspectFit;
         [self addSubview:_imageView];
     }
-    
+
     [self setUpConstraints];
 }
 
 - (void)updateView {
-    _imageView.image = [UIImage imageWithContentsOfFile:_intervention.imageURL.path];
+    _imageView.image = [UIImage imageNamed:_intervention.imageURL.path];
 }
 
 - (void)setUpConstraints {
     [NSLayoutConstraint deactivateConstraints:_constraints];
-    
+
     _constraints = [NSMutableArray new];
-    
+
     _imageView.translatesAutoresizingMaskIntoConstraints = NO;
-    
+
     [_constraints addObjectsFromArray:@[
                                         [NSLayoutConstraint constraintWithItem:_imageView
                                                                      attribute:NSLayoutAttributeCenterX
@@ -113,7 +113,7 @@ static const CGFloat TrailingMargin = 20.0;
                                                                     multiplier:1.0
                                                                       constant:-TrailingMargin],
                                         ]];
-    
+
     [NSLayoutConstraint activateConstraints:_constraints];
 }
 


### PR DESCRIPTION
R: @samerce 

Use imageNamed rather than imageWithContentsOfFile so that different px densities are automatically resolved
